### PR TITLE
Controlar img de perfil y banner de servicio por rol

### DIFF
--- a/admin/newService.php
+++ b/admin/newService.php
@@ -2,8 +2,11 @@
   session_start();
   require('../models/categoria.php');
   require('../models/provincia.php');
+  require('../models/usuario.php');
   $categorias = Categoria::traerCategoria();
   $provincias = Provincia::traerProvincia();
+
+  
 ?>
 
 <!DOCTYPE html>
@@ -23,6 +26,9 @@
     if(!isset($_SESSION["s_id_usuario"])){
       header("Location:../index.php");
     }
+
+    $idUsuario = $_SESSION["s_id_usuario"];
+    $usuario = mysqli_fetch_array(Usuario::getUsuario($idUsuario));
   ?>
   <!-- End Header -->
 
@@ -153,7 +159,9 @@
                         <input name="renewpassword" type="password" class="form-control" id="renewPassword" maxlength="30" pattern="[!-~]{8,30}" required>
                       </div>
                     </div> -->
-
+                    <?php
+                      if($usuario["FK_idRol"] == 4 || $usuario["FK_idRol"] == 5 || $usuario["FK_idRol"] == 7){
+                    ?>
                     <h4 class="card-title">Imágenes y archivos</h4>
 
                     <div class="row mb-3">
@@ -163,15 +171,19 @@
                           <input name="imgLogo" class="form-control" type="file" id="btnSubirImgLogo" accept="image/png, .jpeg, .jpg" required>
                         </div>
                     </div>
-
+                    
                     <div class="row mb-3">
                       <label for="imgBanner" class="col-md-4 col-lg-3 col-form-label">Imagen de banner</label>
                       <div class="col-md-8 col-lg-9">
                         <!-- <img class="imgBanner" id="imgBanner" src="" alt="Profile"> -->
                         <input name="imgBanner" class="form-control" type="file" id="btnSubirImgBanner" accept="image/png, .jpeg, .jpg">
                       </div>
-                    </div>                     
-  
+                    </div>    
+                    
+                    <!-- agregar galeria -->
+                    <?php
+                      }
+                    ?>
                     <!-- <div class="row mb-3">
                       <label for="company" class="col-md-4 col-lg-3 col-form-label">Galeria de imagen</label>
                       <div class="col-md-8 col-lg-9">

--- a/admin/updateService.php
+++ b/admin/updateService.php
@@ -166,23 +166,32 @@
                       </div>
                     </div> -->
 
+                    <?php
+                      if($servicio["FK_idRol"] == 4 || $servicio["FK_idRol"] == 5 || $servicio["FK_idRol"] == 7){
+                    ?>
                     <h4 class="card-title">Imágenes y archivos</h4>
 
                     <div class="row mb-3">
                       <label for="imgLogo" class="col-md-4 col-lg-3 col-form-label">Imagen de servicio <span class="camposObligatorios">*</span></label>
                       <div class="col-md-8 col-lg-9">
                           <!-- <img id="imgLogo" src="" alt="Profile"> -->
-                          <input name="imgLogo" class="form-control" type="file" id="btnSubirImgLogo" accept="image/png, .jpeg, .jpg">
+                          <input name="imgLogo" class="form-control" type="file" id="btnSubirImgLogo" accept="image/png, .jpeg, .jpg" required>
                         </div>
                     </div>
-
+                    
                     <div class="row mb-3">
                       <label for="imgBanner" class="col-md-4 col-lg-3 col-form-label">Imagen de banner</label>
                       <div class="col-md-8 col-lg-9">
                         <!-- <img class="imgBanner" id="imgBanner" src="" alt="Profile"> -->
                         <input name="imgBanner" class="form-control" type="file" id="btnSubirImgBanner" accept="image/png, .jpeg, .jpg">
                       </div>
-                    </div>                     
+                    </div>  
+                    
+                    
+                      <!-- agregar galeria -->
+                    <?php
+                      }
+                    ?>                    
   
                     <!-- <div class="row mb-3">
                       <label for="company" class="col-md-4 col-lg-3 col-form-label">Galeria de imagen</label>

--- a/controller/newService.php
+++ b/controller/newService.php
@@ -2,6 +2,7 @@
 session_start();
 require('./../models/servicio.php');
 require('./../assets/php/uploadImg.php');
+require('./../models/usuario.php');
 $servicio = $_POST;
 $imagenes  = Array(
     'Img' => $_FILES["imgLogo"],
@@ -55,8 +56,11 @@ if(
     
     $Servicio = new Servicio();
 
-    $nameImgServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'img_'.$servicio["nombreServicio"]);   
-    $nameBannerServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'imgBanner_'.$servicio["nombreServicio"]);
+    $usr_servicio = Usuario::getUsuario($_SESSION["s_id_usuario"]);
+    $usr_servicio = mysqli_fetch_array($usr_servicio);
+
+    $nameImgServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'service_'.$usr_servicio["user_login"]);   
+    $nameBannerServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'imgBanner_'.$usr_servicio["user_login"]);
     $addServicio = $Servicio::addServicio($servicio["nombreServicio"],$servicio["descripción"],$servicio["emailContacto"],$servicio["telefono"],$servicio["sitioWeb"],$nameImgServicio.'.webp',$nameBannerServicio.'.webp',$servicio["provincia"],$servicio["departamento"],$_SESSION["s_id_usuario"],$_SESSION["s_nombre"]);
 
     if($addServicio){
@@ -99,6 +103,9 @@ if(
             
             $addTipo = $Servicio::addTipoServicios($servicio["tipo"],$idLastServicio,$_SESSION["s_nombre"]);
 
+            /* SUBIDA DE FOTOS DE PERFIL Y BANNER DE SERVICIO */
+
+
             foreach($imagenes as $tipoImg => $img){
                 $name_img = ($tipoImg === "Img")? $nameImgServicio : $nameBannerServicio;
                 $dir_img = ($img["name"] != "") 
@@ -107,10 +114,12 @@ if(
 
                 if($dir_img!="--"){
                     if(!file_exists($dir_img))
-                        mkdir($dir_img,7777,true);
+                        mkdir($dir_img,0777,true);
                     Imagen::upload($img,$name_img,$dir_img);
                 }
             }
+
+            /* SUBIDA DE FOTOS DE GALERIA */
 
             header("Location: ./../admin/index.php?successService");
         }

--- a/controller/updateService.php
+++ b/controller/updateService.php
@@ -13,8 +13,11 @@ $imagenes  = Array(
 if($servicio["nombreServicio"] != null && $servicio["telefono"]!= null && $servicio["descripción"] != null && $servicio["categoria"]!= null && $servicio["provincia"] != null && $servicio["departamento"] != null && isset($_SESSION["s_id_usuario"]) && isset($_SESSION["s_nombre"])){
     $modelServicio = new Servicio();
     
-    $nameImgServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'img_'.$servicio["nombreServicio"]);   
-    $nameBannerServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'imgBanner_'.$servicio["nombreServicio"]);
+    $usr_servicio = $modelServicio::getServicio($servicio["idServicio"]);
+    $usr_servicio = mysqli_fetch_array($usr_servicio);
+
+    $nameImgServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'service_'.$usr_servicio["user_login"]);   
+    $nameBannerServicio = preg_replace('/[^a-zA-Z0-9._ ]/', '', 'imgBanner_'.$usr_servicio["user_login"]);
     
     $updateServicio = $modelServicio::updateServicio($servicio["idServicio"],$servicio["nombreServicio"],$servicio["descripción"],$servicio["emailContacto"],$servicio["telefono"],$servicio["sitioWeb"],$nameImgServicio.'.webp',$nameBannerServicio.'.webp',$servicio["provincia"],$servicio["departamento"],$_SESSION["s_id_usuario"],$_SESSION["s_nombre"]);
 
@@ -68,7 +71,7 @@ if($servicio["nombreServicio"] != null && $servicio["telefono"]!= null && $servi
                         : "--";
                 if($dir_img!="--"){
                 if(!file_exists($dir_img))
-                    mkdir($dir_img,7777,true);
+                    mkdir($dir_img,0777,true);
                 $updateImageService = Imagen::upload($img,$name_img,$dir_img);
             }
         }


### PR DESCRIPTION
Se agrega el control segun rol de img de servicio y de banner, ahora si el usuario no cuenta con el rol necesario no puede ver en el form los inputs de img y de banner (pendiente agregar el de galeria cuando se haga merge)

Tambien se corrige un poco la subida de img y de banner, segun lo que cambiaste antes parece que funciona todo ok, cambie un tema de nombres nomas.

**NOTA**: Pendiente agregar funcionalidad para consumir imagenes genericas en el caso del plan gratuito